### PR TITLE
Turning off prefetch for pages that not in the routes list

### DIFF
--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -50,6 +50,11 @@ describe('UrlPrettifier getPrettyUrl', (): void => {
     expect(router.getPrettyUrl('unknownPage', {id: 1}))
       .toEqual({href: '/unknownPage?id=1'});
   });
+
+  it('should return href and prefetch equal to false if the route does not exist', (): void => {
+    expect(router.getPrettyUrl('unknownPage', {id: 1, preventPrefetchIfNoRoute: true}))
+      .toEqual({href: '/unknownPage?id=1', prefetch: false});
+  });
 });
 
 describe('UrlPrettifier getPrettyUrlPatterns (DEPRECATED)', (): void => {

--- a/src/index.js
+++ b/src/index.js
@@ -36,11 +36,12 @@ export default class UrlPrettifier<T: string> {
     ;
   }
 
-  getPrettyUrl(pageName: T, params: ParamType): RouteLinkParamsType {
+  getPrettyUrl(pageName: T, {preventPrefetchIfNoRoute = false, ...params}: {preventPrefetchIfNoRoute: boolean, params: ParamType}): RouteLinkParamsType {
     const route: ?RouteType<T> = this.routes.filter((currentRoute: RouteType<T>): boolean =>
       currentRoute.page === pageName)[0];
     return {
       href: `/${pageName}${this.paramsToQueryString(params)}`,
+      ...(preventPrefetchIfNoRoute && !route && {prefetch: false}),
       ...(route && route.prettyUrl
         ? {as: typeof route.prettyUrl === 'string' ? route.prettyUrl : route.prettyUrl(params)}
         : {}


### PR DESCRIPTION
Hi.
Maybe it's a nice idea to turn off `prefetch` (which is default to `true`) if we don't have a page in the routes list? 

> Example: We are migrating site from monolith to next.js app. Now we have to manually set `prefetch={false}` to all links, that lead to the monolith or get 404 on prefetch attempt. But we will need to remove them after the migration is done. It would be nice to not crawl thru the project to fix all the links. And this way it can be done automatically. 

With all best regards. Anton.